### PR TITLE
Fix SMJClientUtility.m

### DIFF
--- a/SMJobKit/SMJClientUtility.m
+++ b/SMJobKit/SMJClientUtility.m
@@ -20,7 +20,7 @@
   SecStaticCodeRef codeRef;
   OSStatus result;
   
-  result = SecStaticCodeCreateWithPath((__bridge CFURLRef)[NSURL URLWithString:bundlePath], kSecCSDefaultFlags, &codeRef);
+  result = SecStaticCodeCreateWithPath((__bridge CFURLRef)[NSURL fileURLWithPath:bundlePath], kSecCSDefaultFlags, &codeRef);
   if (result != noErr)
   {
     if (result == errSecCSUnsigned)


### PR DESCRIPTION
(__bridge CFURLRef)[NSURL URLWithString:bundlePath]
returns NULL if the path contains a whitespace. The correct method to use is:
(__bridge CFURLRef)[NSURL fileURLWithPath:bundlePath]